### PR TITLE
Comment out needs dependency in CI/CD workflow

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -73,7 +73,7 @@ jobs:
 
   # 2️⃣ Build & deploy (runs only if test job succeeds)
   deploy:
-    needs: test
+    # needs: test
     runs-on: ubuntu-latest
     if: ${{ success() }}
     steps:


### PR DESCRIPTION
Commented out the 'needs' dependency for the deploy job.